### PR TITLE
ci(release): prove staged SDK baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 # Normalize line endings: text files are stored with LF in the repository.
 * text=auto
+pnpm-lock.yaml text eol=lf
+*.patch text eol=lf
 
 # Explicit binaries (never normalize)
 *.png binary

--- a/.github/workflows/p0.yml
+++ b/.github/workflows/p0.yml
@@ -1,4 +1,4 @@
-name: P0 source gate
+name: P0 source and staged release gate
 
 on:
   pull_request:
@@ -16,6 +16,8 @@ jobs:
   verify-p0:
     runs-on: windows-2022
     timeout-minutes: 45
+    env:
+      ARTIFACTS_DIR: artifacts/p0
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -29,5 +31,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri
+      - uses: actions/cache@v4
+        with:
+          path: .runtime-cache
+          key: ${{ runner.os }}-release-runtime-${{ hashFiles('scripts/release-runtime.lock.json') }}
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify:p0
+      - run: pnpm package:sidecar:with-node
+      - run: pnpm validate:resources
+      - run: pnpm smoke:staged-host
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: p0-resource-layout-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/p0
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/operations/pi-sdk-0.82.1-upgrade.md
+++ b/docs/operations/pi-sdk-0.82.1-upgrade.md
@@ -1,0 +1,40 @@
+# Pi SDK 0.82.1 Upgrade
+
+## Baseline
+
+- Source commit: `8859c1e414c368d762ffab8f0f0a23ea3f4e483f`
+- Annotated tag: `pre-pi-sdk-0.82.1-8859c1e414c`
+- Pi SDK packages: `0.80.7`
+- Minimum development Node: `22.19.0`
+- Controlled release Node: `24.18.0`
+- pnpm: `9.15.0`
+
+## Baseline Artifacts
+
+- `pnpm-lock.yaml` SHA-256: `a92c3c10f44c0bfcb8a80b8588ff798d9d5b2cdde0e618d4784eee4eb8790af6`
+- `patches/@earendil-works__pi-coding-agent@0.80.7.patch` SHA-256: `ef9e0f8e9bc6eddc8005e5f425c140d2a52cc0072c4115a0a553ddaedac6baca`
+
+The release lock had retained the pnpm-lock hash from commit `1e9266f`. Later lockfile changes in `d202930`, `c65ac7c`, and `eaa8b6c` were source-compatible but were not repinned. PR-0A repairs that pre-existing release-baseline drift before changing Node or Pi SDK versions.
+
+## Verification
+
+- macOS frozen install: passed
+- macOS docs, typecheck, and JavaScript/TypeScript tests: passed
+- macOS production build: passed
+- macOS Rust tests: 34 passed
+- Windows controlled runtime staging: required in CI
+- Windows staged resource validation: required in CI
+- Windows staged Host smoke: required in CI
+
+The staged Host smoke launches the generated compacted bootstrap with the controlled Node runtime and an isolated `PI_CODING_AGENT_DIR`. It requires `host.ready`, `system.getStatus`, atomic `system.rehydrate`, exact `system.shutdown`, and a zero process exit.
+
+## Upgrade Boundaries
+
+- Keep Pi SDK at `0.80.7` through lifecycle and release-version-source prerequisites.
+- Upgrade `pi-ai`, `pi-coding-agent`, and `pi-tui` to `0.82.1` in one atomic migration.
+- Preserve Node `>=22.19.0` as the minimum compatibility contract.
+- Do not produce a release candidate until the announced post-2026-07-27 Node 24 security release is pinned by URL and SHA-256.
+
+## Rollback Anchor
+
+Rollback restores the complete previous signed artifact, its release runtime lock, its pnpm lockfile, and the `0.80.7` SDK patch. Do not replace individual npm packages inside an installed artifact.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "package:sidecar:with-node": "node scripts/package-release-sidecar.mjs --prepare-runtime",
     "prepare:runtime": "node scripts/prepare-release-runtime.mjs",
     "validate:resources": "node scripts/validate-resource-layout.mjs",
+    "smoke:staged-host": "node scripts/smoke-staged-host.mjs",
     "verify:docs": "node scripts/verify-doc-links.mjs",
     "test:rust": "node scripts/prepare-rust-test-resources.mjs && cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --target-dir apps/desktop/src-tauri/target/verify-rust",
     "package:release": "node scripts/package-release.mjs",

--- a/scripts/compact-pi-host-resources.mjs
+++ b/scripts/compact-pi-host-resources.mjs
@@ -14,6 +14,7 @@ import {
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const hostDir = join(root, "apps/desktop/src-tauri/resources/pi-host");
@@ -24,6 +25,10 @@ const MIN_ZIP_BYTES = 1_000_000; // real SDK tree is tens of MB
 function die(msg) {
   console.error("[compact]", msg);
   process.exit(1);
+}
+
+function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
 // Windows ships bsdtar at System32\tar.exe (supports -a zip and drive-letter
@@ -148,6 +153,7 @@ if (existsSync(stagingPath)) {
   s.nodeModulesPackagedAs = "node_modules.zip";
   s.bootstrapEntry = "main.js -> extract zip -> host-main.js";
   s.zipBytes = statSync(zipPath).size;
+  s.nodeModulesZipSha256 = sha256File(zipPath);
   writeFileSync(stagingPath, JSON.stringify(s, null, 2));
 }
 

--- a/scripts/package-release-sidecar.mjs
+++ b/scripts/package-release-sidecar.mjs
@@ -26,7 +26,6 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { tmpdir } from "node:os";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const hostDist = join(root, "packages/pi-host/dist");
@@ -167,7 +166,10 @@ function proveRuntimeImports(hostDir) {
  * directory can recursively package the destination itself when pnpm walks the workspace.
  */
 function stageHostWithDeploy() {
-  const deployedFrom = join(tmpdir(), `pi-host-deploy-${process.pid}-${Date.now()}`);
+  // pnpm 9 resolves deploy links incorrectly when the workspace and target are
+  // on different Windows drives. Keep the target outside the workspace but on
+  // the checkout volume.
+  const deployedFrom = join(dirname(root), `.pideck-host-deploy-${process.pid}-${Date.now()}`);
   try {
     rmSync(deployedFrom, { recursive: true, force: true });
     console.log("[package-sidecar] pnpm deploy --prod ->", deployedFrom);

--- a/scripts/release-runtime.lock.json
+++ b/scripts/release-runtime.lock.json
@@ -37,7 +37,7 @@
   },
   "pnpmLock": {
     "path": "pnpm-lock.yaml",
-    "sha256": "fc39c85c9d74af95fa7fa65abf9a79666a9dd72624c57e738adccd9fcf9d3b54"
+    "sha256": "a92c3c10f44c0bfcb8a80b8588ff798d9d5b2cdde0e618d4784eee4eb8790af6"
   },
   "hostProductionDeps": {
     "strategy": "pnpm-deploy-from-frozen-lockfile",

--- a/scripts/smoke-staged-host.mjs
+++ b/scripts/smoke-staged-host.mjs
@@ -1,0 +1,229 @@
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const resources = join(root, "apps", "desktop", "src-tauri", "resources");
+const lock = JSON.parse(
+  readFileSync(join(root, "scripts", "release-runtime.lock.json"), "utf8"),
+);
+const nodePath =
+  process.env.PIDECK_STAGED_NODE ?? join(resources, "node", "node.exe");
+const hostEntry =
+  process.env.PIDECK_STAGED_HOST_ENTRY ?? join(resources, "pi-host", "main.js");
+const expectedNodeVersion =
+  process.env.PIDECK_EXPECT_NODE_VERSION ?? lock.node.version;
+const timeoutMs = parseTimeout(process.env.PIDECK_STAGED_SMOKE_TIMEOUT_MS, 180_000);
+
+function parseTimeout(value, fallback) {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid PIDECK_STAGED_SMOKE_TIMEOUT_MS: ${value}`);
+  }
+  return parsed;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function withStderr(message, stderr) {
+  const tail = stderr.trim();
+  return tail ? `${message}\nstderr tail:\n${tail}` : message;
+}
+
+assert(existsSync(nodePath), `Staged Node is missing: ${nodePath}`);
+assert(existsSync(hostEntry), `Staged Host entry is missing: ${hostEntry}`);
+
+const tempRoot = mkdtempSync(join(tmpdir(), "pideck-staged-smoke-"));
+const agentDir = join(tempRoot, "agent");
+mkdirSync(agentDir, { recursive: true, mode: 0o700 });
+for (const name of ["auth.json", "models.json", "settings.json"]) {
+  writeFileSync(join(agentDir, name), "{}\n", { encoding: "utf8", mode: 0o600 });
+}
+
+const child = spawn(nodePath, [hostEntry], {
+  cwd: dirname(hostEntry),
+  env: {
+    ...process.env,
+    PI_CODING_AGENT_DIR: agentDir,
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+  windowsHide: true,
+});
+child.stdout.setEncoding("utf8");
+child.stderr.setEncoding("utf8");
+
+let stdoutBuffer = "";
+let stderrTail = "";
+let streamClosedError = null;
+const messages = [];
+const messageWaiters = [];
+const exitPromise = new Promise((resolve) => {
+  child.once("exit", (code, signal) => resolve({ code, signal }));
+});
+
+function rejectMessageWaiters(error) {
+  streamClosedError = error;
+  for (const waiter of messageWaiters.splice(0)) {
+    clearTimeout(waiter.timer);
+    waiter.reject(error);
+  }
+}
+
+function enqueueMessage(message) {
+  const waiter = messageWaiters.shift();
+  if (!waiter) {
+    messages.push(message);
+    return;
+  }
+  clearTimeout(waiter.timer);
+  waiter.resolve(message);
+}
+
+child.stdout.on("data", (chunk) => {
+  stdoutBuffer += chunk;
+  let newline;
+  while ((newline = stdoutBuffer.indexOf("\n")) >= 0) {
+    const line = stdoutBuffer.slice(0, newline).trim();
+    stdoutBuffer = stdoutBuffer.slice(newline + 1);
+    if (!line) continue;
+    try {
+      enqueueMessage(JSON.parse(line));
+    } catch (error) {
+      rejectMessageWaiters(
+        new Error(`Staged Host emitted invalid JSONL: ${line}`, { cause: error }),
+      );
+    }
+  }
+});
+
+child.stderr.on("data", (chunk) => {
+  stderrTail = (stderrTail + chunk).slice(-32_768);
+});
+child.once("error", (error) => rejectMessageWaiters(error));
+child.once("close", (code, signal) => {
+  rejectMessageWaiters(
+    new Error(withStderr(`Staged Host closed with code=${code} signal=${signal}`, stderrTail)),
+  );
+});
+
+function nextMessage(deadline) {
+  if (messages.length > 0) return Promise.resolve(messages.shift());
+  if (streamClosedError) return Promise.reject(streamClosedError);
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return Promise.reject(new Error("Timed out waiting for staged Host output"));
+  return new Promise((resolve, reject) => {
+    const waiter = {
+      resolve,
+      reject,
+      timer: setTimeout(() => {
+        const index = messageWaiters.indexOf(waiter);
+        if (index >= 0) messageWaiters.splice(index, 1);
+        reject(new Error(withStderr("Timed out waiting for staged Host output", stderrTail)));
+      }, remaining),
+    };
+    messageWaiters.push(waiter);
+  });
+}
+
+async function waitForEvent(event, deadline) {
+  while (Date.now() < deadline) {
+    const message = await nextMessage(deadline);
+    if (message.event === event) return message;
+  }
+  throw new Error(`Timed out waiting for event ${event}`);
+}
+
+async function request(method, context, params, deadline) {
+  const id = randomUUID();
+  child.stdin.write(`${JSON.stringify({ protocolVersion: 1, id, method, context, params })}\n`);
+  while (Date.now() < deadline) {
+    const message = await nextMessage(deadline);
+    if (message.id === id) return message;
+  }
+  throw new Error(`Timed out waiting for response ${method}`);
+}
+
+async function waitForExit(deadline) {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new Error("Timed out waiting for staged Host exit");
+  let timer;
+  try {
+    return await Promise.race([
+      exitPromise,
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(withStderr("Timed out waiting for staged Host exit", stderrTail))),
+          remaining,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+let cleanExit = false;
+try {
+  const deadline = Date.now() + timeoutMs;
+  const ready = await waitForEvent("host.ready", deadline);
+  const readyStatus = ready.payload;
+  const hostInstanceId = ready.hostInstanceId ?? readyStatus?.hostInstanceId;
+  assert(typeof hostInstanceId === "string", "host.ready did not include hostInstanceId");
+  assert(
+    readyStatus?.sdkVersion === lock.sdk,
+    `Expected SDK ${lock.sdk}, got ${readyStatus?.sdkVersion}`,
+  );
+  assert(
+    readyStatus?.nodeVersion === `v${expectedNodeVersion}`,
+    `Expected Node v${expectedNodeVersion}, got ${readyStatus?.nodeVersion}`,
+  );
+
+  const context = { expectedHostInstanceId: hostInstanceId };
+  const status = await request("system.getStatus", context, null, deadline);
+  assert(status.ok === true, `system.getStatus failed: ${JSON.stringify(status.error)}`);
+  assert(status.result?.hostInstanceId === hostInstanceId, "system.getStatus identity mismatch");
+
+  const rehydrate = await request("system.rehydrate", context, null, deadline);
+  assert(rehydrate.ok === true, `system.rehydrate failed: ${JSON.stringify(rehydrate.error)}`);
+  assert(Number.isSafeInteger(rehydrate.result?.watermark), "rehydrate watermark is missing");
+  assert(rehydrate.result?.host?.hostInstanceId === hostInstanceId, "rehydrate identity mismatch");
+
+  const shutdown = await request("system.shutdown", context, null, deadline);
+  assert(shutdown.ok === true, `system.shutdown failed: ${JSON.stringify(shutdown.error)}`);
+  assert(shutdown.result?.accepted === true, "system.shutdown was not accepted");
+
+  const exited = await waitForExit(deadline);
+  assert(exited.code === 0, withStderr(`Staged Host exited with code=${exited.code}`, stderrTail));
+  cleanExit = true;
+  console.log(
+    JSON.stringify({
+      status: "ok",
+      sdkVersion: readyStatus.sdkVersion,
+      nodeVersion: readyStatus.nodeVersion,
+      rehydrateWatermark: rehydrate.result.watermark,
+      exitCode: exited.code,
+    }),
+  );
+} finally {
+  if (!cleanExit) {
+    child.kill();
+    await Promise.race([
+      exitPromise,
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+  }
+  rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/scripts/validate-resource-layout.mjs
+++ b/scripts/validate-resource-layout.mjs
@@ -12,6 +12,10 @@ const res = join(root, "apps/desktop/src-tauri/resources");
 const errors = [];
 const info = {};
 
+function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
 function need(p, msg) {
   if (!existsSync(p)) errors.push(msg ?? `missing ${p}`);
 }
@@ -36,6 +40,7 @@ const compacted = existsSync(zipPath) && statSync(zipPath).size > 1_000_000;
 if (compacted) {
   info.layout = "compacted-zip";
   info.zipBytes = statSync(zipPath).size;
+  info.nodeModulesZipSha256 = sha256File(zipPath);
   need(hostMain, "host-main.js missing in compacted layout");
   // Bootstrap main.js must reference zip
   const mainSrc = readFileSync(join(res, "pi-host/main.js"), "utf8");
@@ -87,6 +92,11 @@ if (existsSync(join(res, "pi-host/STAGING.json"))) {
   if (s.pnpmLockVerified !== true && s.pnpmLockSha256) {
     // optional
   }
+  if (compacted && s.nodeModulesZipSha256 !== info.nodeModulesZipSha256) {
+    errors.push(
+      `STAGING node_modules zip SHA-256 ${s.nodeModulesZipSha256 ?? "missing"} !== ${info.nodeModulesZipSha256}`,
+    );
+  }
   info.staging = {
     sdk: s.sdk,
     usedProcessExecPath: s.usedProcessExecPath,
@@ -94,6 +104,10 @@ if (existsSync(join(res, "pi-host/STAGING.json"))) {
     unlockedNpmInstall: s.unlockedNpmInstall,
     stagingStrategy: s.stagingStrategy,
     nodeModulesPackagedAs: s.nodeModulesPackagedAs ?? null,
+    nodeModulesZipSha256: s.nodeModulesZipSha256 ?? null,
+    pnpmLockSha256: s.pnpmLockSha256 ?? null,
+    pnpmLockVerified: s.pnpmLockVerified ?? false,
+    runtimeLockSdk: s.runtimeLockSdk ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

- repin the audited current pnpm lock hash while keeping Pi SDK 0.80.7 and release Node 24.18.0
- add Windows controlled-runtime staging, resource validation, and staged Host JSONL smoke to P0
- retain SDK, runtime, lockfile, and compacted dependency archive hash evidence
- document the upgrade baseline and rollback anchor

## Local verification

- `pnpm verify:docs`
- `pnpm verify:quick` (protocol 355, Host 263, desktop 324)
- `pnpm build`
- `pnpm test:rust` (34 passed)
- staged Host smoke against workspace build on Node 22.19.0

## Required gate

Windows P0 must prove `package:sidecar:with-node`, resource layout validation, and the compacted staged Host smoke before PR-0A is complete.