### PR TITLE
fix: 防止思考强度标签换行

### DIFF
--- a/apps/desktop/src/features/chat/ModelControls.dom.test.tsx
+++ b/apps/desktop/src/features/chat/ModelControls.dom.test.tsx
@@ -237,4 +237,65 @@ describe("Model controls", () => {
 
     expect(container.querySelector("[data-composer-thinking-control]")).not.toBeInTheDocument();
   });
+
+  it("keeps Extra high as one thinking-level item and sends xhigh", async () => {
+    useAppStore.getState().setThinkingLevels(["off", "high", "xhigh", "max"]);
+    vi.spyOn(hostClient, "request").mockImplementation(async (method: string) => {
+      if (method !== "model.setThinkingLevel") throw new Error(`Unexpected method ${method}`);
+      return envelope(method, { ...session(), thinkingLevel: "xhigh" }) as never;
+    });
+    const user = userEvent.setup();
+    render(<ThinkingLevelControl />);
+
+    await user.click(screen.getByRole("button", { name: "Thinking level, currently Off" }));
+    const menu = screen.getByRole("menu", { name: "Thinking level, currently Off" });
+    const extra = screen.getByRole("menuitemradio", { name: /^Extra high$/ });
+    expect(menu).toHaveClass("w-max");
+    expect(extra).toHaveClass("whitespace-nowrap");
+    expect(screen.getByRole("menuitemradio", { name: /^High$/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitemradio", { name: /^Max$/ })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitemradio", { name: /^Extra$/ })).not.toBeInTheDocument();
+    await user.click(extra);
+
+    expect(hostClient.request).toHaveBeenCalledWith("model.setThinkingLevel", expect.anything(), {
+      level: "xhigh",
+    });
+  });
+
+  it("keeps Extra high as one item in the model thinking submenu", async () => {
+    const model: ModelSummary = {
+      ...MODEL,
+      thinkingLevels: ["off", "high", "xhigh", "max"],
+    };
+    vi.spyOn(hostClient, "request").mockImplementation(async (method: string) => {
+      if (method === "model.list") {
+        return envelope(method, {
+          models: [model],
+          current: model,
+          thinkingLevels: ["off", "high", "xhigh", "max"],
+          enabledProviders: ["muapi"],
+        }) as never;
+      }
+      if (method === "model.setThinkingLevel") {
+        return envelope(method, { ...session(), model, thinkingLevel: "xhigh" }) as never;
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    useAppStore.getState().applySessionSnapshot({ ...session(), model });
+    const user = userEvent.setup();
+    render(<ModelControls />);
+
+    await user.click(await screen.findByRole("button", { name: "muapi/Grok 4.5" }));
+    await user.click(screen.getByRole("button", { name: "Thinking level for muapi/Grok 4.5" }));
+    const submenu = screen.getByRole("menu", { name: "Thinking level for muapi/Grok 4.5" });
+    const extra = screen.getByRole("menuitemradio", { name: /^Extra high$/ });
+    expect(submenu).toHaveClass("w-max");
+    expect(extra).toHaveClass("whitespace-nowrap");
+    expect(screen.queryByRole("menuitemradio", { name: /^Extra$/ })).not.toBeInTheDocument();
+    await user.click(extra);
+
+    expect(hostClient.request).toHaveBeenCalledWith("model.setThinkingLevel", expect.anything(), {
+      level: "xhigh",
+    });
+  });
 });

--- a/apps/desktop/src/features/chat/ModelControls.tsx
+++ b/apps/desktop/src/features/chat/ModelControls.tsx
@@ -339,7 +339,7 @@ export function ThinkingLevelControl() {
       <button
         ref={triggerRef}
         type="button"
-        className="flex h-7 cursor-pointer items-center gap-1 text-[11px] text-muted outline-none transition-colors hover:text-foreground focus-visible:ring-1 focus-visible:ring-focus disabled:cursor-default disabled:opacity-40"
+        className="flex h-7 cursor-pointer items-center gap-1 whitespace-nowrap text-[11px] text-muted outline-none transition-colors hover:text-foreground focus-visible:ring-1 focus-visible:ring-focus disabled:cursor-default disabled:opacity-40"
         aria-label={accessibleLabel}
         title={accessibleLabel}
         aria-haspopup="menu"
@@ -361,7 +361,7 @@ export function ThinkingLevelControl() {
           ref={menuRef}
           role="menu"
           aria-label={accessibleLabel}
-          className="theme-floating-surface absolute bottom-full right-0 z-50 mb-2 min-w-28 overflow-hidden rounded-md border border-border bg-surface-raised py-0.5 shadow-lg"
+          className="theme-floating-surface absolute bottom-full right-0 z-50 mb-2 min-w-28 w-max overflow-hidden rounded-md border border-border bg-surface-raised py-0.5 shadow-lg"
         >
           {levels.map((level) => {
             const active = level === currentLevel;
@@ -373,7 +373,7 @@ export function ThinkingLevelControl() {
                 aria-checked={active}
                 aria-busy={pending || undefined}
                 disabled={pending}
-                className={`flex h-7 w-full items-center gap-1.5 px-2 text-left text-[11px] outline-none transition-colors focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-focus disabled:opacity-50 ${
+                className={`flex h-7 w-full items-center gap-1.5 whitespace-nowrap px-2 text-left text-[11px] outline-none transition-colors focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-focus disabled:opacity-50 ${
                   active
                     ? "bg-accent/15 text-accent"
                     : "text-muted hover:bg-surface-overlay hover:text-foreground"
@@ -805,7 +805,7 @@ export function ModelControls() {
             </div>
             {thinkingModel && (
               <div
-                className="theme-floating-surface absolute left-full ml-2 min-w-[112px] overflow-hidden rounded-md border border-border bg-surface-raised py-1 shadow-lg"
+                className="theme-floating-surface absolute left-full ml-2 min-w-[112px] w-max overflow-hidden rounded-md border border-border bg-surface-raised py-1 shadow-lg"
                 style={{ top: thinkingMenuTop }}
                 role="menu"
                 aria-label={t("modelThinkingFor", { model: modelOptionLabel(thinkingModel) })}
@@ -821,7 +821,7 @@ export function ModelControls() {
                       <button
                         key={level}
                         type="button"
-                        className={`flex h-7 w-full items-center gap-1.5 px-2 text-left text-[11px] capitalize ${
+                        className={`flex h-7 w-full items-center gap-1.5 whitespace-nowrap px-2 text-left text-[11px] capitalize ${
                           active
                             ? "bg-accent/15 text-accent"
                             : "text-muted hover:bg-surface-overlay hover:text-foreground"


### PR DESCRIPTION
## 问题

思考强度触发器和菜单项（如 Extra high）在窄宽度下会折成两行，菜单看起来像重复项。

这只处理标签换行，不覆盖 #10 里的大小写去重、粘贴图片、工作区别名等其他项。

## 改动

- 思考强度按钮和菜单项增加 `whitespace-nowrap`
- 菜单容器使用 `w-max`，按最长标签撑开

## 测试

- 补充 ModelControls DOM 测试，覆盖 composer 与模型选择器两处思考菜单
- 已在 macOS arm64 实机确认标签不再换行