### PR TITLE
fix: 阻止 macOS 方向键向输入栏插入控制字符

### DIFF
--- a/apps/desktop/src/features/chat/Composer.tsx
+++ b/apps/desktop/src/features/chat/Composer.tsx
@@ -45,6 +45,7 @@ import {
 } from "../../lib/bridge/host-context";
 import { subscribeValidatedHostEvent } from "../../lib/bridge/validated-host-events";
 import { subscribeComposerInsert } from "../../lib/composer-insert";
+import { attachMacArrowKeyInsertGuard } from "../../lib/mac-arrow-key-insert";
 import { BUILTIN_COMMANDS, matchBuiltinCommand } from "./builtin-commands";
 import { abortCompaction, requestCompact } from "./compaction-actions";
 import { SessionStatsModal } from "./SessionStatsModal";
@@ -59,6 +60,7 @@ import {
   pickDesktopAttachmentPaths,
   readDesktopSmallFile,
 } from "../../lib/desktop-file-access";
+import { resolveWindowControlsPlatform } from "../../components/WindowControls";
 import { contextMenuTrigger, openContextMenu } from "../../lib/context-menu";
 import { shouldKeepNativeContextMenu } from "../../lib/context-menu-policy";
 import { buildTextContextMenuItems } from "../../lib/text-context-menu";
@@ -391,6 +393,12 @@ export function Composer({
       }),
     [],
   );
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    return attachMacArrowKeyInsertGuard(textarea, resolveWindowControlsPlatform() === "macos");
+  }, []);
 
   // Attachments are per-conversation; drop them when the session changes.
   useEffect(() => {

--- a/apps/desktop/src/lib/mac-arrow-key-insert.test.ts
+++ b/apps/desktop/src/lib/mac-arrow-key-insert.test.ts
@@ -1,0 +1,108 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it } from "vitest";
+import { attachMacArrowKeyInsertGuard, isMacArrowKeyControlInsert } from "./mac-arrow-key-insert";
+
+const ARROW_CONTROLS = {
+  left: "\u001c",
+  right: "\u001d",
+  up: "\u001e",
+  down: "\u001f",
+} as const;
+
+function insertText(data: string, inputType = "insertText") {
+  return { inputType, data };
+}
+
+describe("isMacArrowKeyControlInsert", () => {
+  it("matches the four Mac arrow-key control codes on macOS insertText", () => {
+    for (const data of Object.values(ARROW_CONTROLS)) {
+      expect(isMacArrowKeyControlInsert(insertText(data), true)).toBe(true);
+    }
+  });
+
+  it("ignores the same payloads off macOS", () => {
+    for (const data of Object.values(ARROW_CONTROLS)) {
+      expect(isMacArrowKeyControlInsert(insertText(data), false)).toBe(false);
+    }
+  });
+
+  it("preserves ordinary text, CJK, emoji, and newlines", () => {
+    for (const data of ["a", "中", "🙂", "\n", "\r", "hello\nworld", " "]) {
+      expect(isMacArrowKeyControlInsert(insertText(data), true)).toBe(false);
+    }
+  });
+
+  it("does not treat paste, IME, undo, or mixed payloads as arrow inserts", () => {
+    expect(
+      isMacArrowKeyControlInsert(insertText(ARROW_CONTROLS.right, "insertFromPaste"), true),
+    ).toBe(false);
+    expect(
+      isMacArrowKeyControlInsert(insertText(ARROW_CONTROLS.right, "insertCompositionText"), true),
+    ).toBe(false);
+    expect(isMacArrowKeyControlInsert({ inputType: "historyUndo", data: null }, true)).toBe(false);
+    expect(isMacArrowKeyControlInsert(insertText(`${ARROW_CONTROLS.right}a`), true)).toBe(false);
+    expect(isMacArrowKeyControlInsert(insertText(""), true)).toBe(false);
+    expect(isMacArrowKeyControlInsert(insertText(ARROW_CONTROLS.right), false)).toBe(false);
+  });
+});
+
+describe("attachMacArrowKeyInsertGuard", () => {
+  let textarea: HTMLTextAreaElement;
+
+  afterEach(() => {
+    textarea.remove();
+  });
+
+  function mount(value = "hello"): HTMLTextAreaElement {
+    textarea = document.createElement("textarea");
+    textarea.value = value;
+    document.body.append(textarea);
+    textarea.focus();
+    textarea.setSelectionRange(2, 2);
+    return textarea;
+  }
+
+  function dispatchInsert(data: string, inputType = "insertText"): InputEvent {
+    const event = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      data,
+      inputType,
+    });
+    textarea.dispatchEvent(event);
+    return event;
+  }
+
+  it("cancels arrow-control insertText on macOS without moving the caret or changing value", () => {
+    mount();
+    const detach = attachMacArrowKeyInsertGuard(textarea, true);
+    const event = dispatchInsert(ARROW_CONTROLS.right);
+    expect(event.defaultPrevented).toBe(true);
+    expect(textarea.value).toBe("hello");
+    expect(textarea.selectionStart).toBe(2);
+    expect(textarea.selectionEnd).toBe(2);
+    detach();
+  });
+
+  it("does not intercept ordinary insertText, paste, or non-macOS control inserts", () => {
+    mount();
+    const detach = attachMacArrowKeyInsertGuard(textarea, true);
+    expect(dispatchInsert("a").defaultPrevented).toBe(false);
+    expect(dispatchInsert("中文").defaultPrevented).toBe(false);
+    expect(dispatchInsert("🙂").defaultPrevented).toBe(false);
+    expect(dispatchInsert("\n").defaultPrevented).toBe(false);
+    expect(dispatchInsert("pasted\ntext", "insertFromPaste").defaultPrevented).toBe(false);
+    detach();
+
+    const offMac = attachMacArrowKeyInsertGuard(textarea, false);
+    expect(dispatchInsert(ARROW_CONTROLS.left).defaultPrevented).toBe(false);
+    offMac();
+  });
+
+  it("stops intercepting after cleanup", () => {
+    mount();
+    const detach = attachMacArrowKeyInsertGuard(textarea, true);
+    detach();
+    expect(dispatchInsert(ARROW_CONTROLS.up).defaultPrevented).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/mac-arrow-key-insert.ts
+++ b/apps/desktop/src/lib/mac-arrow-key-insert.ts
@@ -1,0 +1,37 @@
+/**
+ * On macOS, Tauri's `unstable` child-webview path lets AppKit treat arrow keys as
+ * `insertText` of the classic Mac control codes (Left FS, Right GS, Up RS, Down US).
+ * They render as tofu boxes and persist into the draft. See tauri#10194.
+ *
+ * Cancel only that `insertText` payload. Do not touch keydown (caret/selection),
+ * IME, paste, undo, or other C0 characters that a prompt may legitimately contain.
+ */
+
+const ARROW_KEY_CONTROL_MIN = 0x1c;
+const ARROW_KEY_CONTROL_MAX = 0x1f;
+
+export type BeforeInputLike = {
+  inputType?: string;
+  data?: string | null;
+};
+
+export function isMacArrowKeyControlInsert(event: BeforeInputLike, isMac: boolean): boolean {
+  if (!isMac || event.inputType !== "insertText" || event.data == null) return false;
+  if (event.data.length !== 1) return false;
+  const code = event.data.charCodeAt(0);
+  return code >= ARROW_KEY_CONTROL_MIN && code <= ARROW_KEY_CONTROL_MAX;
+}
+
+function cancelMacArrowKeyControlInsert(event: Event, isMac: boolean): boolean {
+  if (!isMacArrowKeyControlInsert(event as BeforeInputLike, isMac)) return false;
+  event.preventDefault();
+  return true;
+}
+
+export function attachMacArrowKeyInsertGuard(element: EventTarget, isMac: boolean): () => void {
+  const onBeforeInput = (event: Event) => {
+    cancelMacArrowKeyControlInsert(event, isMac);
+  };
+  element.addEventListener("beforeinput", onBeforeInput, true);
+  return () => element.removeEventListener("beforeinput", onBeforeInput, true);
+}


### PR DESCRIPTION
## 问题

Fixes #12

在 macOS 上左右移动输入栏光标时，会不断插入无字形的豆腐块字符，并且会进入草稿、随消息发出。Windows 不复现。

根因是 Tauri `unstable` 子 WebView 路径上，AppKit 把方向键交给 `interpretKeyEvents:` → `insertText:`，插入经典 Mac 控制字符：

- Left：U+001C
- Right：U+001D
- Up：U+001E
- Down：U+001F

详见 [tauri#10194](https://github.com/tauri-apps/tauri/issues/10194)。PiCove 需要 `unstable` 才能创建浏览器子 WebView，不能靠关掉该 feature 来修。

## 改动

在 composer textarea 上挂 capture 阶段的 `beforeinput` 监听，仅取消 macOS 上上述单字符 `insertText`。不拦截：

- 方向键 keydown（光标/选区）
- IME
- 粘贴
- 撤销
- 普通文本 / CJK / emoji / 换行

## 测试

- 增加 `mac-arrow-key-insert` 单测（四种控制字符、非 macOS、IME/粘贴/撤销、监听清理）
- 已在 macOS arm64 实机确认：左右移动光标不再插入豆腐块